### PR TITLE
Add IdentifierPrototype

### DIFF
--- a/sources/main/dansandu/ballotin/identifier_prototype.hpp
+++ b/sources/main/dansandu/ballotin/identifier_prototype.hpp
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <ostream>
+#include <string>
+
+namespace dansandu::ballotin::identifier_prototype
+{
+
+template<typename Tag, typename Integer>
+class IdentifierPrototype
+{
+public:
+    friend constexpr auto operator<=>(const IdentifierPrototype& left, const IdentifierPrototype& right) = default;
+
+    friend std::ostream& operator<<(std::ostream& stream, const IdentifierPrototype identifierPrototype)
+    {
+        return stream << identifierPrototype.integer_;
+    }
+
+    using IntegerType = Integer;
+
+    constexpr IdentifierPrototype() : integer_{0}
+    {
+    }
+
+    constexpr explicit IdentifierPrototype(const IntegerType integer) : integer_{integer}
+    {
+    }
+
+    constexpr IntegerType getInteger() const
+    {
+        return integer_;
+    }
+
+    std::string toString() const
+    {
+        return std::to_string(integer_);
+    }
+
+private:
+    IntegerType integer_;
+};
+
+}

--- a/sources/test/dansandu/ballotin/identifier_prototype.test.cpp
+++ b/sources/test/dansandu/ballotin/identifier_prototype.test.cpp
@@ -1,0 +1,74 @@
+#include "dansandu/ballotin/identifier_prototype.hpp"
+#include "dansandu/radiance/radiance.hpp"
+
+#include <sstream>
+
+using dansandu::ballotin::identifier_prototype::IdentifierPrototype;
+
+class IntegerIdentifierTag
+{
+};
+
+using IntegerIdentifier = IdentifierPrototype<IntegerIdentifierTag, int>;
+
+TEST_CASE("identifier_prototype")
+{
+    const auto integer = 59;
+
+    const auto biggerInteger = 101;
+
+    const auto identifier = IntegerIdentifier{integer};
+
+    const auto biggerIdentifier = IntegerIdentifier{biggerInteger};
+
+    SECTION("integer conversion")
+    {
+        REQUIRE(identifier.getInteger() == integer);
+
+        REQUIRE(biggerIdentifier.getInteger() == biggerInteger);
+    }
+
+    SECTION("string conversion")
+    {
+        REQUIRE(identifier.toString() == "59");
+
+        REQUIRE(biggerIdentifier.toString() == "101");
+    }
+
+    SECTION("stream operations #1")
+    {
+        auto stream = std::stringstream{};
+
+        stream << identifier;
+
+        REQUIRE(stream.str() == "59");
+    }
+
+    SECTION("stream operations #2")
+    {
+        auto stream = std::stringstream{};
+
+        stream << biggerIdentifier;
+
+        REQUIRE(stream.str() == "101");
+    }
+
+    SECTION("relational operations")
+    {
+        REQUIRE(identifier == identifier);
+
+        REQUIRE(identifier <= identifier);
+
+        REQUIRE(identifier >= identifier);
+
+        REQUIRE(identifier != biggerIdentifier);
+
+        REQUIRE(identifier < biggerIdentifier);
+
+        REQUIRE(biggerIdentifier > identifier);
+
+        REQUIRE(identifier <= biggerIdentifier);
+
+        REQUIRE(biggerIdentifier >= identifier);
+    }
+}


### PR DESCRIPTION
Used to create named, unique, strongly typed integer types. Can be used to create unique keys or sequence numbers without allowing implicit conversion to other arithmetic types. Also, provides default implementation such as relational operations and string representation.